### PR TITLE
fixed recursion errors of `Expressions.__eq__` (#212)

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -116,10 +116,15 @@ class Expression(StrAndRepr):
         return hash(self.identity_tuple)
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.identity_tuple == other.identity_tuple
+        return self._eq_check_cycles(other, set())
 
     def __ne__(self, other):
         return not (self == other)
+
+    def _eq_check_cycles(self, other, checked):
+        # keep a set of all pairs that are already checked, so we won't fall into infinite recursions.
+        checked.add((id(self), id(other)))
+        return other.__class__ is self.__class__ and self.identity_tuple == other.identity_tuple
 
     def resolve_refs(self, rule_map):
         # Nothing to do on the base expression.
@@ -324,17 +329,18 @@ class Compound(Expression):
         self.members = tuple(m.resolve_refs(rule_map) for m in self.members)
         return self
 
+    def _eq_check_cycles(self, other, checked):
+        return (
+            super()._eq_check_cycles(other, checked) and
+            len(self.members) == len(other.members) and
+            all(m._eq_check_cycles(mo, checked) for m, mo in zip(self.members, other.members) if (id(m), id(mo)) not in checked)
+        )
+
     def __hash__(self):
         # Note we leave members out of the hash computation, since compounds can get added to
         # sets, then have their members mutated. See RuleVisitor._resolve_refs.
         # Equality should still work, but we want the rules to go into the correct hash bucket.
         return hash((self.__class__, self.name))
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, self.__class__) and
-            self.name == other.name and
-            self.members == other.members)
 
 
 class Sequence(Compound):
@@ -398,6 +404,12 @@ class Lookahead(Compound):
     def _as_rhs(self):
         return '%s%s' % ('!' if self.negativity else '&', self._unicode_members()[0])
 
+    def _eq_check_cycles(self, other, checked):
+        return (
+            super()._eq_check_cycles(other, checked) and
+            self.negativity == other.negativity
+        )
+
 def Not(term):
     return Lookahead(term, negative=True)
 
@@ -443,6 +455,13 @@ class Quantifier(Compound):
         else:
             qualifier = '{%d,%d}' % (self.min, self.max)
         return '%s%s' % (self._unicode_members()[0], qualifier)
+
+    def _eq_check_cycles(self, other, checked):
+        return (
+            super()._eq_check_cycles(other, checked) and
+            self.min == other.min and
+            self.max == other.max
+        )
 
 def ZeroOrMore(member, name=''):
     return Quantifier(member, name=name, min=0, max=float('inf'))

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -7,7 +7,7 @@ import pytest
 
 from parsimonious.exceptions import BadGrammar, LeftRecursionError, ParseError, UndefinedLabel, VisitationError
 from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher, is_callable
-from parsimonious.grammar import rule_grammar, RuleVisitor, Grammar, TokenGrammar, LazyReference
+from parsimonious.grammar import rule_grammar, rule_syntax, RuleVisitor, Grammar, TokenGrammar, LazyReference
 from parsimonious.nodes import Node
 from parsimonious.utils import Token
 
@@ -540,6 +540,19 @@ class GrammarTests(TestCase):
             for example in examples:
                 with pytest.raises(ParseError):
                     grammar[rule].parse(example)
+
+    def test_equal(self):
+        grammar_def = (r"""
+            x = y / z / ""
+            y = "y" x
+            z = "z" x
+        """)
+        assert Grammar(grammar_def) == Grammar(grammar_def)
+
+        self.assertEqual(Grammar(rule_syntax), Grammar(rule_syntax))
+        self.assertNotEqual(Grammar('expr = ~"[a-z]{1,3}"'), Grammar('expr = ~"[a-z]{2,3}"'))
+        self.assertNotEqual(Grammar('expr = ~"[a-z]{1,3}"'), Grammar('expr = ~"[a-z]{1,4}"'))
+        self.assertNotEqual(Grammar('expr = &"a"'), Grammar('expr = !"a"'))
 
 
 class TokenGrammarTests(TestCase):


### PR DESCRIPTION
* fixed `__eq__`

* `_eq_no_recursion` ---> `_eq_check_cycles`

* Update parsimonious/tests/test_grammar.py

Co-authored-by: [object Object] <lucas.wiman@gmail.com>

Co-authored-by: FelisNivalis <@>
Co-authored-by: [object Object] <lucas.wiman@gmail.com>